### PR TITLE
Updating opcode $BF table entry

### DIFF
--- a/AccuracyCoin.asm
+++ b/AccuracyCoin.asm
@@ -612,7 +612,7 @@ Suite_UnofficialOps__AX:
 	table "$AF   LAX absolute",   $FF, result_UnOp_LAX_AF, TEST_LAX_AF
 	table "$B3   LAX indirect,Y", $FF, result_UnOp_LAX_B3, TEST_LAX_B3
 	table "$B7   LAX zeropage,Y", $FF, result_UnOp_LAX_B7, TEST_LAX_B7
-	table "$BF   LAX absolute,X", $FF, result_UnOp_LAX_BF, TEST_LAX_BF
+	table "$BF   LAX absolute,Y", $FF, result_UnOp_LAX_BF, TEST_LAX_BF
 	.byte $FF
 	
 	;; Unofficial Instructions: DCP ;;


### PR DESCRIPTION
While doing some testing, I noticed the opcode for $BF read as absolute-x, but I believe it's actually absolute-y. The underlying test case seems to work correctly so it might just be a label issue. I also double checked the [dev wiki](https://www.nesdev.org/wiki/CPU_unofficial_opcodes) just to be sure. Submitting a PR for consideration if this is the case.