### PR TITLE
Fix: Error message 7 of Palette Ram Quirks Markdown styling not worki…

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ or
   3: The backdrop colors for palettes 1, 2, and 3 should not be mirrors of the backdrop color of palette 0.  
   4: The backdrop colors for sprites should be mirrors of the backdrop colors for backgrounds.  
   5: The values read from Palette RAM should only be 6-bit, with the upper 2 bits being PPU open bus.  
-  6: With "Greyscale Mode" enabled, the lower four bits of the value read should all be zero.
+  6: With "Greyscale Mode" enabled, the lower four bits of the value read should all be zero.  
   7: With "Greyscale Mode" enabled, the lower four bits of the value written should be unaffected.
 
 ### Rendering Flag Behavior


### PR DESCRIPTION
I was kinda annoyed at the missing line wrap before error code 7 in the palette ram quirks section of the Readme, so I fixed it